### PR TITLE
Feat/createhire

### DIFF
--- a/freehaeyo/src/Assets/selectedCheckBox.svg
+++ b/freehaeyo/src/Assets/selectedCheckBox.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="24" cy="24" r="23.5" fill="#7000FF" stroke="#7000FF"/>
+<path d="M11.25 23.625L21 33.375L36.375 18" stroke="white" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/freehaeyo/src/Assets/unSelectedCheckBox.svg
+++ b/freehaeyo/src/Assets/unSelectedCheckBox.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="24" cy="24" r="23.5" fill="white" stroke="#BEBEBE"/>
+<path d="M11.25 23.625L21 33.375L36.375 18" stroke="#BEBEBE" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/freehaeyo/src/Pages/CreateHire.jsx
+++ b/freehaeyo/src/Pages/CreateHire.jsx
@@ -1,41 +1,111 @@
-import CompanyCard from "../Components/Common/CompanyCard";
-import CompanyInfoCard from "../Components/Common/MyPage/CompanyInfoCard";
-import {Link} from 'react-router-dom';
+import CompanyCard from '../Components/Common/CompanyCard';
+import CompanyInfoCard from '../Components/Common/MyPage/CompanyInfoCard';
+import Header from '../Components/Common/Header';
 
-function CreateHire(){
-    return(
-        <>
-            <div>
-                <p>채용 올리기</p>
-                <main>
-                    <section>
-                        <form>
-                            <div>
-                                <p>제목</p><span>*</span>
-                                <p>채용하실 직군을 정확하게 입력해주세요</p>
-                                <input type="text" placeholder="제목을 입력해주세요"/>
-                            </div>
-                            <div>
-                                <p>내용</p><span>*</span>
-                                <p>자격 요건, 우대 사항, 기술 스택 등을 입력해주세요</p>
-                                <input type="text" placeholder="내용을 상세하게 입력해주세요"/>
-                            </div>
-                            <div>
-                                <p>마감일</p>
-                                <input type="date"/>
-                            </div>
-                            <button>채용 올리기</button>
-                        </form>
-                    </section>
-                    <section>
-                        <CompanyCard/>
-                        <CompanyInfoCard/>
-                        <button><Link to="/changecompanyinfo">회사 정보 수정하기</Link></button>
-                    </section>
-                </main>
-            </div>
-        </>
-    )
+import unSelectedCheckBox from '../Assets/unSelectedCheckBox.svg';
+import SelectedCheckBox from '../Assets/selectedCheckBox.svg';
+
+import CompanyData from '../MockData/CompanyData.json';
+
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+
+function CreateHire() {
+  // Todo: 현재 로그인한 companyId값 받아오기
+  const currentCompanyId = 1;
+  const currentCompanyData = CompanyData.filter(
+    (company) => company.id === currentCompanyId,
+  )[0];
+
+  const [hireData, setHireData] = useState({});
+
+  function onChangeData(e) {
+    setHireData({
+      ...hireData,
+      [e.target.name]: e.target.value,
+    });
+  }
+
+  function onChangeCheckBox(e) {
+    if (e.target.checked) {
+      setHireData({
+        ...hireData,
+        [e.target.name]: true,
+        dueDate: null,
+      });
+    } else {
+      setHireData({
+        ...hireData,
+        [e.target.name]: false,
+      });
+    }
+  }
+
+  //Todo: Submit button 클릭 시 hireData를 서버로 보내기
+
+  return (
+    <>
+      <Header />
+      <div>
+        <p>채용 올리기</p>
+        <main>
+          <section>
+            <form>
+              <div>
+                <p>제목</p>
+                <span>*</span>
+                <p>채용하실 직군을 정확하게 입력해주세요</p>
+                <input
+                  name="title"
+                  type="text"
+                  placeholder="제목을 입력해주세요"
+                  onChange={onChangeData}
+                />
+              </div>
+              <div>
+                <p>내용</p>
+                <span>*</span>
+                <p>자격 요건, 우대 사항, 기술 스택 등을 입력해주세요</p>
+                <input
+                  name="content"
+                  type="text"
+                  placeholder="내용을 상세하게 입력해주세요"
+                  onChange={onChangeData}
+                />
+              </div>
+              <div>
+                <p>마감일</p>
+                <span>*</span>
+                <input
+                  type="date"
+                  name="dueDate"
+                  onChange={onChangeData}
+                  disabled={hireData.openingAllTime}
+                />
+                <div>
+                  <input
+                    id="openingAllTime"
+                    type="checkbox"
+                    name="openingAllTime"
+                    onChange={onChangeCheckBox}
+                  />
+                  <label htmlFor="openingAllTime">상시 채용</label>
+                </div>
+              </div>
+              <button>채용 올리기</button>
+            </form>
+          </section>
+          <section>
+            <CompanyCard companyData={currentCompanyData} />
+            <CompanyInfoCard companyData={currentCompanyData} />
+            <button>
+              <Link to="/changecompanyinfo">회사 정보 수정하기</Link>
+            </button>
+          </section>
+        </main>
+      </div>
+    </>
+  );
 }
 
 export default CreateHire;


### PR DESCRIPTION
### Description
- Asset에 체크박스 추가
- 채용 페이지
   - 입력 데이터 value값 모으는 hireData 변수 선언
   - company Data 각 company Card에 props로 전달
   - 상시채용 체크박스 선택 시 data 안에 dueDate:null로 변경 및 마감일 인풋 박스 비활성화

### Screenshot
<img width="682" alt="스크린샷 2023-11-18 오후 7 59 38" src="https://github.com/heoh06/freehaeyo/assets/124794790/4a03ae29-f8fd-47d7-b6e0-dbafd844a430">

### Issue
- [ ] 로그인한 company ID 상태관리로 가져오기
- [ ] 채용 올리기 버튼 클릭 시 hireData 서버로 POST 되어야 함
